### PR TITLE
Correct a bug when exiting.

### DIFF
--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -271,7 +271,7 @@ static void *threadpool_thread(void *threadpool)
             pthread_cond_wait(&(pool->notify), &(pool->lock));
         }
 
-        if(pool->shutdown) {
+        if(pool->shutdown && pool->count ==0) {
             break;
         }
 


### PR DESCRIPTION
The previous code could make the worker thread exit without finishing
all work in the queue. With this modification we make sure the queue is
empty before exiting all worker threads. Moreover, the main thread will
wait for all worker threads when try to join them all, assuring all work
is done before exiting.
