### PR TITLE
Fix Warnings

### DIFF
--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -97,6 +97,7 @@ threadpool_t *threadpool_create(int thread_count, int queue_size, int flags)
 {
     threadpool_t *pool;
     int i;
+    (void) flags;
 
     /* TODO: Check for negative or otherwise very big input parameters */
 
@@ -148,6 +149,7 @@ int threadpool_add(threadpool_t *pool, void (*function)(void *),
 {
     int err = 0;
     int next;
+    (void) flags;
 
     if(pool == NULL || function == NULL) {
         return threadpool_invalid;


### PR DESCRIPTION
````
lib/threadpool.c:96:71: error: unused parameter 'flags' [-Werror,-Wunused-parameter]
threadpool_t *threadpool_create(int thread_count, int queue_size, int flags)
                                                                      ^
lib/threadpool.c:147:40: error: unused parameter 'flags' [-Werror,-Wunused-parameter]
                   void *argument, int flags)
                                       ^
2 errors generated.
````