### PR TITLE
FIX: warning: ISO C90 forbids mixed declarations and code [-Wpedantic]

### DIFF
--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -95,14 +95,15 @@ int threadpool_free(threadpool_t *pool);
 
 threadpool_t *threadpool_create(int thread_count, int queue_size, int flags)
 {
-    if(thread_count <= 0 || thread_count > MAX_THREADS || queue_size <= 0 || queue_size > MAX_QUEUE) {
-        return NULL;
-    }
-    
+
     threadpool_t *pool;
     int i;
     (void) flags;
 
+    if(thread_count <= 0 || thread_count > MAX_THREADS || queue_size <= 0 || queue_size > MAX_QUEUE) {
+        return NULL;
+    }
+    
     if((pool = (threadpool_t *)malloc(sizeof(threadpool_t))) == NULL) {
         goto err;
     }

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -95,7 +95,6 @@ int threadpool_free(threadpool_t *pool);
 
 threadpool_t *threadpool_create(int thread_count, int queue_size, int flags)
 {
-
     threadpool_t *pool;
     int i;
     (void) flags;


### PR DESCRIPTION
Environment: 
- Ubuntu 14.04 LTS
- gcc 4.9.3

Fix the warning for -pedantic:
`src/threadpool.c:102:5: warning: ISO C90 forbids mixed declarations and code [-Wpedantic]`

Maybe you can append -std=c99 to CFLAG in Makefile. C99 is allowed it.