### PR TITLE
Destroying a locked mutex is undefined behaviour

### DIFF
--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -255,6 +255,7 @@ int threadpool_free(threadpool_t *pool)
            mutex and condition variable, we're sure they're
            initialized. Let's lock the mutex just in case. */
         pthread_mutex_lock(&(pool->lock));
+        pthread_mutex_unlock(&(pool->lock));
         pthread_mutex_destroy(&(pool->lock));
         pthread_cond_destroy(&(pool->notify));
     }


### PR DESCRIPTION
https://linux.die.net/man/3/pthread_mutex_destroy

```
Attempting to destroy a locked mutex results in undefined behavior. 
```

Bug found with ThreadSanitizer