### PR TITLE
docs: fix simple typo, addtional -> additional

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Currently, the implementation:
 Possible enhancements
 =====================
 
-The API contains addtional unused 'flags' parameters that would allow
+The API contains additional unused 'flags' parameters that would allow
 some additional options:
 
  * Lazy creation of threads (easy)


### PR DESCRIPTION
There is a small typo in README.md.

Should read `additional` rather than `addtional`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md