### PR TITLE
bug fix: Unlock mutex before breaking from shutdown

### DIFF
--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -211,6 +211,7 @@ int threadpool_destroy(threadpool_t *pool, int flags)
     do {
         /* Already shutting down */
         if(pool->shutdown) {
+            pthread_mutex_unlock(&(pool->lock));
             err = threadpool_shutdown;
             break;
         }


### PR DESCRIPTION
Coverity scanning found it